### PR TITLE
[Fix] Prevent state emission after BLoC is closed

### DIFF
--- a/lib/presentation/notifications/bloc/notification_bloc.dart
+++ b/lib/presentation/notifications/bloc/notification_bloc.dart
@@ -33,6 +33,7 @@ class NotificationBloc extends Bloc<NotificationEvent, NotificationState> {
       if (!isFromTestEnvironment) {
         await Future.delayed(const Duration(seconds: 3));
       }
+      if (isClosed) return;
       List<NotificationModel> notificationList = [];
       notificationList = List.of(dummyNotifications);
       emit(


### PR DESCRIPTION
# Pull Request

## Description
- Prevented the state emission after BLoC is closed in the notification Bloc

## Type of Change
<!-- Please check the appropriate options -->
- [x] Bug fix
- [ ] New feature
- [ ] Code refactoring
- [ ] Test cases
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Build configuration change
- [ ] Other (please describe):

## Screenshots (if applicable)
<!-- Add screenshots here if UI changes were made (Skip if golden tests are added) -->

## Checklist
- [x] Before requesting for review, I have self reviewed all the changes in this PR
- [x] My code follows the project's coding style guidelines
- [ ] I have added any necessary tests
- [x] New and existing tests pass locally with my changes
- [x] Github pipeline passes with my changes

## Additional Notes
<!-- Any additional information that reviewers should know -->
