### PR TITLE
[Fix] App crash for release build caused by RevenueCat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "DEV_API_BASE_URL=${{ secrets.DEV_API_BASE_URL }}"  > .env
-          echo "REVENEUCAT_GOOGLE_API_KEY=${{ secrets.REVENEUCAT_GOOGLE_API_KEY }}" >> .env
-          echo "REVENEUCAT_GOOGLE_RELEASE_API_KEY=${{ secrets.REVENEUCAT_GOOGLE_RELEASE_API_KEY }}" >> .env
+          echo "REVENEUCAT_TEST_STORE_API_KEY=${{ secrets.REVENEUCAT_TEST_STORE_API_KEY }}" >> .env
 
       - name: 3.2 Create Firebase options files (decode from base64)
         run: |

--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -67,8 +67,7 @@ const String kProduct = 'product';
 const String kHome = 'home';
 
 // RevenueCat subscription constants
-const revenueCatGoogleApiKey = 'REVENEUCAT_GOOGLE_API_KEY';
-const revenueCatGoogleReleaseApiKey = 'REVENEUCAT_GOOGLE_RELEASE_API_KEY';
+const revenueCatTestStoreApiKey = 'REVENEUCAT_TEST_STORE_API_KEY';
 const revenueCatMonthly = 'monthly';
 
 // Invoice constants

--- a/lib/presentation/my_orders/bloc/my_order_bloc.dart
+++ b/lib/presentation/my_orders/bloc/my_order_bloc.dart
@@ -4,8 +4,8 @@ import 'package:skelter/presentation/checkout/model/invoice_model.dart';
 import 'package:skelter/presentation/home/domain/usecases/get_products.dart';
 import 'package:skelter/presentation/my_orders/bloc/my_order_event.dart';
 import 'package:skelter/presentation/my_orders/bloc/my_order_state.dart';
-import 'package:skelter/presentation/product_detail/domain/usecases/get_product_detail.dart';
 import 'package:skelter/presentation/my_orders/services/pdf_service.dart';
+import 'package:skelter/presentation/product_detail/domain/usecases/get_product_detail.dart';
 import 'package:skelter/utils/permission_util.dart';
 
 class MyOrderBloc extends Bloc<MyOrderEvent, MyOrderState> {

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -52,11 +52,11 @@ class SubscriptionService {
         debugPrint('RevenueCat API key is missing!');
         return;
       }
-      // NOTE: REVENUECAT RELEASE BYPASS
+      
       // We are bypassing RevenueCat initialization in release mode because
       // the production stores (App Store/Google Play) are not yet fully implemented.
       //
-      // CRITICAL PRODUCTION CHECKLIST BEFORE RELEASE:
+      // IMPORTANT PRODUCTION CHECKLIST BEFORE RELEASE:
       // (To prevent crashes and unexpected behavior):
       // - Never submit apps to App Store or Google Play using a Test Store key.
       // - Ensure platform-specific Production Keys (iOS/Android) are used.

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -42,15 +42,34 @@ class SubscriptionService {
 
     try {
       await Purchases.setLogLevel(LogLevel.debug);
-      // Note: Release builds require a separate RevenueCat API key.
-      // Ensure the release API key is configured before app publishing.
-      final revenueCatApiKey = kReleaseMode
-          ? dotenv.env[revenueCatGoogleReleaseApiKey]
-          : dotenv.env[revenueCatGoogleApiKey];
+      // Note: Test Store uses a separate API key from your real store API keys.
+      // Development/Testing: Use Test Store API Key.
+      // Platform Store API Keys (iOS, Android, etc.): Use for production builds
+
+      // CURRENT IMPLEMENTATION: We are using the Test Store API Key
+      final revenueCatApiKey = dotenv.env[revenueCatTestStoreApiKey];
       if (revenueCatApiKey == null || revenueCatApiKey.isEmpty) {
         debugPrint('RevenueCat API key is missing!');
         return;
       }
+      // NOTE: REVENUECAT RELEASE BYPASS
+      // We are bypassing RevenueCat initialization in release mode because
+      // the production stores (App Store/Google Play) are not yet fully implemented.
+      //
+      // CRITICAL PRODUCTION CHECKLIST BEFORE RELEASE:
+      // (To prevent crashes and unexpected behavior):
+      // - Never submit apps to App Store or Google Play using a Test Store key.
+      // - Ensure platform-specific Production Keys (iOS/Android) are used.
+      // - Remove this bypass logic once the store implementation is finalized.
+
+      if (kReleaseMode) {
+        debugPrint(
+          'Bypassing RevenueCat initialization in Release mode '
+          '(Production Store not yet implemented).',
+        );
+        return;
+      }
+
       await Purchases.configure(PurchasesConfiguration(revenueCatApiKey));
       _isPurchaseConfigured = true;
       debugPrint('Purchase configuration initialized successfully');
@@ -61,6 +80,7 @@ class SubscriptionService {
   }
 
   Future<void> _checkSubscriptionStatus() async {
+    if (!_isPurchaseConfigured) return;
     try {
       final customerInfo = await Purchases.getCustomerInfo();
       _updateSubscriptionStatus(customerInfo);
@@ -133,6 +153,7 @@ class SubscriptionService {
   }
 
   Future<String?> getUserManagementUrl() async {
+    if (!_isPurchaseConfigured) return null;
     try {
       final customerInfo = await Purchases.getCustomerInfo();
       return customerInfo.managementURL;


### PR DESCRIPTION
# Pull Request

## Description

- Fix app crash issue for release builds: Implemented a temporary bypass for Release build to allow stable app build and run while production store configurations are pending.
- Add clear developer guidelines and critical warnings regarding the use of Test Store vs. Production API keys.
- Remove dummy key and Correct naming convention for test store API key and update .env file 

## Type of Change
<!-- Please check the appropriate options -->
- [X] Bug fix
- [ ] New feature
- [x] Code refactoring
- [ ] Test cases
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Build configuration change
- [ ] Other (please describe):

## Screenshots (if applicable)
<!-- Add screenshots here if UI changes were made (Skip if golden tests are added) -->

## Checklist
- [X] Before requesting for review, I have self reviewed all the changes in this PR
- [X] My code follows the project's coding style guidelines
- [ ] I have added any necessary tests
- [x] New and existing tests pass locally with my changes
- [X] Github pipeline passes with my changes

## Additional Notes
-  @vishaltsolguruz @ViralsSolguruz Currently We are using the Test Store API Key and not using Release Store key. 

For more detail info please check this :[RevenueCat – CRITICAL warning](https://www.revenuecat.com/docs/getting-started/configuring-sdk#:~:text=CRITICAL%3A%20NEVER%20SUBMIT%20APPS%20WITH%20TEST%20STORE%20API%20KEY)


